### PR TITLE
Avoid phrasing which people are taking offense at.

### DIFF
--- a/server/clc.yaml
+++ b/server/clc.yaml
@@ -17,7 +17,7 @@ executables:
 
 # CLI debug settings
 debug:
-  print_issues: true  # Set to false to suppress all bad word findings in your CLI output
+  print_issues: true  # Set to false to suppress all matched words in your CLI output
   open_server: true   # This means ANYONE can edit your projects and settings. We trust people, right? right?!
 
 # User account settings - uncomment to enable

--- a/server/plugins/background.py
+++ b/server/plugins/background.py
@@ -176,7 +176,7 @@ async def scan_project(server, project, path):
         problems_found = 0
         current_issues = []
 
-        # Precompile all bad words
+        # Precompile all target words
         bad_words_stacked = {}
         bad_words_re = {}
         for word in bad_words:

--- a/server/webui/analysis.html
+++ b/server/webui/analysis.html
@@ -85,14 +85,14 @@
       <textarea id="excludes" style="height: 120px;"></textarea>
     </div>
     <div class="cell">
-      Bad words and context:<br/>
+      Potentially problematic words and context:<br/>
       <textarea id="words" style="height: 120px;"></textarea>
-      <small><i><kbd>word: context</kbd> key/value pairs of bad words and their context</i></small>
+      <small><i><kbd>word: context</kbd> key/value pairs of words and their context</i></small>
     </div>
     <div class="cell">
-      Bad words exclude contexts:<br/>
+      Exclude contexts:<br/>
       <textarea id="excludes_context" style="height: 120px;"></textarea>
-      <small><i>This must be a list of regular expressions that matches contexts in which to ignore bad words.</i></small>
+      <small><i>This must be a list of regular expressions that matches contexts in which to ignore matches.</i></small>
     </div>
     <div class="cell">
       <br/>

--- a/server/webui/projects.html
+++ b/server/webui/projects.html
@@ -51,14 +51,14 @@
           <textarea id="excludes" style="height: 120px;"></textarea>
         </div>
         <div class="cell">
-          Bad words and context:<br/>
+          Potentially problematic words and context:<br/>
           <textarea id="words" style="height: 120px;"></textarea>
-          <small><i><kbd>word: context</kbd> key/value pairs of bad words and their context</i></small>
+          <small><i><kbd>word: context</kbd> key/value pairs of words and their context</i></small>
         </div>
         <div class="cell">
-          Bad words exclude contexts:<br/>
+          Exclude contexts:<br/>
           <textarea id="excludes_context" style="height: 120px;"></textarea>
-          <small><i>This must be a list of regular expressions that matches contexts in which to ignore bad words.</i></small>
+          <small><i>This must be a list of regular expressions that matches contexts in which to ignore word matches.</i></small>
         </div>
       </div>
 
@@ -79,14 +79,14 @@
           <textarea id="org_excludes" style="height: 120px;"></textarea>
         </div>
         <div class="cell">
-          Bad words and context:<br/>
+          Potentially problematic words and context:<br/>
           <textarea id="org_words" style="height: 120px;"></textarea>
-          <small><i><kbd>word: context</kbd> key/value pairs of bad words and their context</i></small>
+          <small><i><kbd>word: context</kbd> key/value pairs of words and their context</i></small>
         </div>
         <div class="cell">
-          Bad words exclude contexts:<br/>
+          Exclude contexts:<br/>
           <textarea id="org_excludes_context" style="height: 120px;"></textarea>
-          <small><i>This must be a list of regular expressions that matches contexts in which to ignore bad words.</i></small>
+          <small><i>This must be a list of regular expressions that matches contexts in which to ignore word matches.</i></small>
         </div>
       </div>
 


### PR DESCRIPTION
Projects are finding the "bad words" phrasing here to imply that we are trying to ban or eliminate the words themselves, rather than considering context. Soften the phrasing.