### PR TITLE
Use SafeLoader, since Loader is a alias for UnsafeLoader

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -41,7 +41,7 @@ try:
     dumper = typing.Union[yaml.Dumper, yaml.CDumper]  # mypy fixups
     from yaml import CLoader as loader, CDumper as dumper
 except:
-    from yaml import Loader as loader, Dumper as dumper
+    from yaml import SafeLoader as loader, Dumper as dumper
 
 
 CLC_VERSION = (0,1,3)


### PR DESCRIPTION
See https://msg.pyyaml.org/load

As this is used to load file that are stored along the git checkout,
a attacker could inject a _clc.yaml or _clc_history.yaml that would
erase the one stored in the directory, and then be able to execute
code since the default loader is not the safe one.

The CLoader shouldn't be affected by the problem.