### PR TITLE
Fix backtrace when _clc_history is empty

### DIFF
--- a/server/plugins/background.py
+++ b/server/plugins/background.py
@@ -120,6 +120,8 @@ async def scan_project(server, project, path):
         excludes_context = yml["excludes_context"]
 
     scan_history = project.history
+    if scan_history is None:
+        scan_history = []
     server.data.activity = f"Preparing to scan {path}..."
 
     params = (


### PR DESCRIPTION
When _clc_history is empty, the yaml loader return None, and so the code
crash later with:

	Traceback (most recent call last):
	  File "/srv/server/main.py", line 207, in <module>
	    pubsub_server.run()
	  File "/srv/server/main.py", line 191, in run
	    loop.run_until_complete(self.server_loop(loop))
	  File "/usr/lib64/python3.10/asyncio/base_events.py", line 646, in run_until_complete
	    return future.result()
	  File "/srv/server/main.py", line 186, in server_loop
	    await plugins.background.run_tasks(self)
	  File "/srv/server/plugins/background.py", line 446, in run_tasks
	    await scan_project(server, server.data.projects[repo], path)
	  File "/srv/server/plugins/background.py", line 269, in scan_project
	    scan_history.append(yml["status"])
	AttributeError: 'NoneType' object has no attribute 'append'